### PR TITLE
2020/06

### DIFF
--- a/bundle.js
+++ b/bundle.js
@@ -137,26 +137,26 @@ document.addEventListener("DOMContentLoaded", () => {
         //set network
         xmlFile.getElementsByTagName("ts:contract")[0].getElementsByTagName("ts:address")[0].setAttribute("network", network);
 
-        xmlFile.getElementsByTagName("ts:name")[0].getElementsByTagName("ts:string")[0].innerHTML = contractName;
+        xmlFile.getElementsByTagName("ts:label")[0].getElementsByTagName("ts:string")[0].innerHTML = contractName;
         xmlFile.getElementsByTagName("ts:contract")[0].getElementsByTagName("ts:address")[0].innerHTML = contractAddress;
         xmlFile.getElementsByTagName("ts:origins")[0].getElementsByTagName("ts:ethereum")[0].setAttribute("contract", contractName);
         xmlFile.getElementsByTagName("ts:contract")[0].attributes.name.value = contractName;
         xmlFile.getElementsByTagName("ts:contract")[0].children[0].value = contractAddress;
-        xmlFile.getElementsByTagName("ts:cards")[0].getElementsByTagName("ts:action")[1]
+        xmlFile.getElementsByTagName("ts:cards")[0].getElementsByTagName("ts:card")[1]
             .getElementsByTagName("ts:transaction")[0].
         getElementsByTagName("ethereum:call")[0].setAttribute("contract", contractName);
 
         //set stripped entity tags
-        xmlFile.getElementsByTagName("ts:token")[0].getElementsByTagName("ts:cards")[0].getElementsByTagName("ts:action")[0]
+        xmlFile.getElementsByTagName("ts:token")[0].getElementsByTagName("ts:cards")[0].getElementsByTagName("ts:card")[0]
             .getElementsByTagName("ts:view")[0].getElementsByTagName("xhtml:style")[0].innerHTML = "&style;";
         xmlFile.getElementsByTagName("ts:token")[0].getElementsByTagName("ts:cards")[0]
-            .getElementsByTagName("ts:action")[0].getElementsByTagName("ts:view")[0]
+            .getElementsByTagName("ts:card")[0].getElementsByTagName("ts:view")[0]
             .getElementsByTagName("xhtml:script")[0].innerHTML = "&about.en;";
 
-        xmlFile.getElementsByTagName("ts:token")[0].getElementsByTagName("ts:cards")[0].getElementsByTagName("ts:action")[1]
+        xmlFile.getElementsByTagName("ts:token")[0].getElementsByTagName("ts:cards")[0].getElementsByTagName("ts:card")[1]
             .getElementsByTagName("ts:view")[0].getElementsByTagName("xhtml:style")[0].innerHTML = "&style;";
         xmlFile.getElementsByTagName("ts:token")[0].getElementsByTagName("ts:cards")[0]
-            .getElementsByTagName("ts:action")[1].getElementsByTagName("ts:view")[0]
+            .getElementsByTagName("ts:card")[1].getElementsByTagName("ts:view")[0]
             .getElementsByTagName("xhtml:script")[0].innerHTML = "&approve.en;";
 
         return xmlFile;
@@ -166,7 +166,7 @@ document.addEventListener("DOMContentLoaded", () => {
         let eventParams = [];
         for(let eventInput of eventAbi.inputs) {
             let elementNode = document.createElement("element");
-            elementNode.setAttribute("name", eventInput.name);
+            elementNode.setAttribute("label", eventInput.name);
             elementNode.setAttribute("ethereum:type", eventInput.type);
             elementNode.setAttribute("ethereum:indexed", eventInput.indexed);
             eventParams.push(elementNode);
@@ -186,12 +186,12 @@ document.addEventListener("DOMContentLoaded", () => {
     function getAttribute(func, contractName) {
         let data = getData(func);
         let attributeTypeNode = document.createElement("ts:attribute-type");
-        attributeTypeNode.setAttribute("id", func.name);
+        attributeTypeNode.setAttribute("name", func.name);
         let syntax = getSyntax(func.outputs);
         if(syntax !== "") {
             attributeTypeNode.setAttribute("syntax", syntax);
         }
-        let nameNode = document.createElement("ts:name");
+        let nameNode = document.createElement("ts:label");
         let stringNodeName = document.createElement("ts:string");
         stringNodeName.setAttribute("xml:lang", "en");
         stringNodeName.innerText = func.name;
@@ -305,9 +305,9 @@ module.exports = {
         "          xmlns:ethereum=\"urn:ethereum:constantinople\"\n" +
         "          custodian=\"false\"\n" +
         ">\n" +
-        "    <ts:name>\n" +
+        "    <ts:label>\n" +
         "        <ts:string xml:lang=\"en\"></ts:string>\n" +
-        "    </ts:name>\n" +
+        "    </ts:label>\n" +
         "    <ts:contract interface=\"erc20\" name=\"\">\n" +
         "        <ts:address network=\"1\"></ts:address>     <!--mainnet-->\n" +
         "    </ts:contract>\n" +
@@ -319,24 +319,24 @@ module.exports = {
         "    </ts:origins>\n" +
         "\n" +
         "    <ts:cards>\n" +
-        "        <ts:action>\n" +
-        "            <ts:name>\n" +
+        "        <ts:card type=\"action\">\n" +
+        "            <ts:label>\n" +
         "                <ts:string xml:lang=\"en\">About</ts:string>\n" +
-        "            </ts:name>\n" +
+        "            </ts:label>\n" +
         "            <ts:view xmlns=\"http://www.w3.org/1999/xhtml\" xml:lang=\"en\">\n" +
         "                <xhtml:style type=\"text/css\">&style;</xhtml:style>\n" +
         "                <xhtml:script type=\"text/javascript\">&about.en;</xhtml:script>\n" +
         "            </ts:view>\n" +
-        "        </ts:action>\n" +
+        "        </ts:card>\n" +
         "\n" +
-        "        <ts:action>\n" +
-        "            <ts:name>\n" +
+        "        <ts:card type=\"action\">\n" +
+        "            <ts:label>\n" +
         "                <ts:string xml:lang=\"en\">Approve</ts:string>\n" +
-        "            </ts:name>\n" +
+        "            </ts:label>\n" +
         "            <ts:attribute-type id=\"approvalAddress\" syntax=\"1.3.6.1.4.1.1466.115.121.1.36\">\n" +
-        "                <ts:name>\n" +
+        "                <ts:label>\n" +
         "                    <ts:string xml:lang=\"en\">Approval Address</ts:string>\n" +
-        "                </ts:name>\n" +
+        "                </ts:label>\n" +
         "                <ts:origins>\n" +
         "                    <ts:user-entry as=\"address\"/>\n" +
         "                </ts:origins>\n" +
@@ -353,10 +353,10 @@ module.exports = {
         "                <xhtml:style type=\"text/css\">&style;</xhtml:style>\n" +
         "                <xhtml:script type=\"text/javascript\">&approve.en;</xhtml:script>\n" +
         "            </ts:view>\n" +
-        "        </ts:action>\n" +
+        "        </ts:card>\n" +
         "    </ts:cards>\n" +
         "\n" +
-        "    <ts:attribute-type id=\"symbol\" syntax=\"1.3.6.1.4.1.1466.115.121.1.26\">\n" +
+        "    <ts:attribute-type name=\"symbol\" syntax=\"1.3.6.1.4.1.1466.115.121.1.26\">\n" +
         "        <ts:origins>\n" +
         "            <ethereum:call as=\"utf8\" function=\"symbol\">\n" +
         "            </ethereum:call>\n" +
@@ -380,9 +380,9 @@ module.exports = {
         "          xmlns:ethereum=\"urn:ethereum:constantinople\"\n" +
         "          custodian=\"false\"\n" +
         ">\n" +
-        "    <ts:name>\n" +
+        "    <ts:label>\n" +
         "        <ts:string xml:lang=\"en\"></ts:string>\n" +
-        "    </ts:name>\n" +
+        "    </ts:label>\n" +
         "    <ts:contract interface=\"erc721\" name=\"\">\n" +
         "        <ts:address network=\"1\"></ts:address>     <!--mainnet-->\n" +
         "    </ts:contract>\n" +
@@ -394,24 +394,24 @@ module.exports = {
         "    </ts:origins>\n" +
         "\n" +
         "    <ts:cards>\n" +
-        "        <ts:action>\n" +
-        "            <ts:name>\n" +
+        "        <ts:card type=\"action\">\n" +
+        "            <ts:label>\n" +
         "                <ts:string xml:lang=\"en\">About</ts:string>\n" +
-        "            </ts:name>\n" +
+        "            </ts:label>\n" +
         "            <ts:view xmlns=\"http://www.w3.org/1999/xhtml\" xml:lang=\"en\">\n" +
         "                <xhtml:style type=\"text/css\">&style;</xhtml:style>\n" +
         "                <xhtml:script type=\"text/javascript\">&about.en;</xhtml:script>\n" +
         "            </ts:view>\n" +
-        "        </ts:action>\n" +
+        "        </ts:card>\n" +
         "\n" +
-        "        <ts:action>\n" +
-        "            <ts:name>\n" +
+        "        <ts:card type=\"action\">\n" +
+        "            <ts:label>\n" +
         "                <ts:string xml:lang=\"en\">Approve</ts:string>\n" +
-        "            </ts:name>\n" +
+        "            </ts:label>\n" +
         "            <ts:attribute-type id=\"approvalAddress\" syntax=\"1.3.6.1.4.1.1466.115.121.1.36\">\n" +
-        "                <ts:name>\n" +
+        "                <ts:label>\n" +
         "                    <ts:string xml:lang=\"en\">Approval Address</ts:string>\n" +
-        "                </ts:name>\n" +
+        "                </ts:label>\n" +
         "                <ts:origins>\n" +
         "                    <ts:user-entry as=\"address\"/>\n" +
         "                </ts:origins>\n" +
@@ -428,10 +428,10 @@ module.exports = {
         "                <xhtml:style type=\"text/css\">&style;</xhtml:style>\n" +
         "                <xhtml:script type=\"text/javascript\">&approve.en;</xhtml:script>\n" +
         "            </ts:view>\n" +
-        "        </ts:action>\n" +
+        "        </ts:card>\n" +
         "    </ts:cards>\n" +
         "\n" +
-        "    <ts:attribute-type id=\"symbol\" syntax=\"1.3.6.1.4.1.1466.115.121.1.26\">\n" +
+        "    <ts:attribute-type name=\"symbol\" syntax=\"1.3.6.1.4.1.1466.115.121.1.26\">\n" +
         "        <ts:origins>\n" +
         "            <ethereum:call as=\"utf8\" function=\"symbol\">\n" +
         "            </ethereum:call>\n" +

--- a/bundle.js
+++ b/bundle.js
@@ -296,10 +296,10 @@ module.exports = {
         "        <!ENTITY about.en SYSTEM \"about.en.js\">\n" +
         "        <!ENTITY approve.en SYSTEM \"approve.en.js\">\n" +
         "        ]>\n" +
-        "<ts:token xmlns:ts=\"http://tokenscript.org/2020/03/tokenscript\"\n" +
+        "<ts:token xmlns:ts=\"http://tokenscript.org/2020/06/tokenscript\"\n" +
         "          xmlns:xhtml=\"http://www.w3.org/1999/xhtml\"\n" +
         "          xmlns:xml=\"http://www.w3.org/XML/1998/namespace\"\n" +
-        "          xsi:schemaLocation=\"http://tokenscript.org/2020/03/tokenscript http://tokenscript.org/2020/03/tokenscript.xsd\"\n" +
+        "          xsi:schemaLocation=\"http://tokenscript.org/2020/06/tokenscript http://tokenscript.org/2020/06/tokenscript.xsd\"\n" +
         "          xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n" +
         "          xmlns:asnx=\"urn:ietf:params:xml:ns:asnx\"\n" +
         "          xmlns:ethereum=\"urn:ethereum:constantinople\"\n" +
@@ -371,10 +371,10 @@ module.exports = {
         "        <!ENTITY about.en SYSTEM \"about.en.js\">\n" +
         "        <!ENTITY approve.en SYSTEM \"approve.en.js\">\n" +
         "        ]>\n" +
-        "<ts:token xmlns:ts=\"http://tokenscript.org/2020/03/tokenscript\"\n" +
+        "<ts:token xmlns:ts=\"http://tokenscript.org/2020/06/tokenscript\"\n" +
         "          xmlns:xhtml=\"http://www.w3.org/1999/xhtml\"\n" +
         "          xmlns:xml=\"http://www.w3.org/XML/1998/namespace\"\n" +
-        "          xsi:schemaLocation=\"http://tokenscript.org/2020/03/tokenscript http://tokenscript.org/2020/03/tokenscript.xsd\"\n" +
+        "          xsi:schemaLocation=\"http://tokenscript.org/2020/06/tokenscript http://tokenscript.org/2020/06/tokenscript.xsd\"\n" +
         "          xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n" +
         "          xmlns:asnx=\"urn:ietf:params:xml:ns:asnx\"\n" +
         "          xmlns:ethereum=\"urn:ethereum:constantinople\"\n" +

--- a/bundle.js
+++ b/bundle.js
@@ -144,7 +144,7 @@ document.addEventListener("DOMContentLoaded", () => {
         xmlFile.getElementsByTagName("ts:contract")[0].children[0].value = contractAddress;
         xmlFile.getElementsByTagName("ts:cards")[0].getElementsByTagName("ts:action")[1]
             .getElementsByTagName("ts:transaction")[0].
-        getElementsByTagName("ts:ethereum")[0].setAttribute("contract", contractName);
+        getElementsByTagName("ethereum:call")[0].setAttribute("contract", contractName);
 
         //set stripped entity tags
         xmlFile.getElementsByTagName("ts:token")[0].getElementsByTagName("ts:cards")[0].getElementsByTagName("ts:action")[0]
@@ -198,7 +198,7 @@ document.addEventListener("DOMContentLoaded", () => {
         nameNode.appendChild(stringNodeName);
         attributeTypeNode.appendChild(nameNode);
         let originNode = document.createElement("ts:origins");
-        let ethereumNode = document.createElement("ts:ethereum");
+        let ethereumNode = document.createElement("ethereum:call");
         ethereumNode.setAttribute("function", func.name);
         ethereumNode.setAttribute("contract", contractName);
         let AS = getAS(func.outputs);
@@ -342,12 +342,12 @@ module.exports = {
         "                </ts:origins>\n" +
         "            </ts:attribute-type>\n" +
         "            <ts:transaction>\n" +
-        "                <ts:ethereum function=\"approve\" contract=\"\" as=\"uint\">\n" +
+        "                <ethereum:call function=\"approve\" contract=\"\" as=\"uint\">\n" +
         "                    <ts:data>\n" +
         "                        <ts:address ref=\"approvalAddress\"/>\n" +
         "                        <ts:uint256>115792089237316195423570985008687907853269984665640564039457584007913129639935</ts:uint256>\n" +
         "                    </ts:data>\n" +
-        "                </ts:ethereum>\n" +
+        "                </ethereum:call>\n" +
         "            </ts:transaction>\n" +
         "            <ts:view xmlns=\"http://www.w3.org/1999/xhtml\" xml:lang=\"en\">\n" +
         "                <xhtml:style type=\"text/css\">&style;</xhtml:style>\n" +
@@ -355,13 +355,14 @@ module.exports = {
         "            </ts:view>\n" +
         "        </ts:action>\n" +
         "    </ts:cards>\n" +
-        "    <!-- placeholder for future functions -->\n" +
+        "\n" +
         "    <ts:attribute-type id=\"symbol\" syntax=\"1.3.6.1.4.1.1466.115.121.1.26\">\n" +
         "        <ts:origins>\n" +
-        "            <ts:ethereum as=\"utf8\" function=\"symbol\">\n" +
-        "            </ts:ethereum>\n" +
+        "            <ethereum:call as=\"utf8\" function=\"symbol\">\n" +
+        "            </ethereum:call>\n" +
         "        </ts:origins>\n" +
         "    </ts:attribute-type>\n" +
+        "\n" +
         "</ts:token>\n",
 
     erc721XML: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
@@ -416,12 +417,12 @@ module.exports = {
         "                </ts:origins>\n" +
         "            </ts:attribute-type>\n" +
         "            <ts:transaction>\n" +
-        "                <ts:ethereum function=\"approve\" contract=\"\" as=\"uint\">\n" +
+        "                <ethereum:call function=\"approve\" contract=\"\" as=\"uint\">\n" +
         "                    <ts:data>\n" +
         "                        <ts:address ref=\"approvalAddress\"/>\n" +
         "                        <ts:uint256 ref=\"tokenId\"/>\n" +
         "                    </ts:data>\n" +
-        "                </ts:ethereum>\n" +
+        "                </ethereum:call>\n" +
         "            </ts:transaction>\n" +
         "            <ts:view xmlns=\"http://www.w3.org/1999/xhtml\" xml:lang=\"en\">\n" +
         "                <xhtml:style type=\"text/css\">&style;</xhtml:style>\n" +
@@ -429,11 +430,11 @@ module.exports = {
         "            </ts:view>\n" +
         "        </ts:action>\n" +
         "    </ts:cards>\n" +
-        "    <!-- placeholder for future functions -->\n" +
+        "\n" +
         "    <ts:attribute-type id=\"symbol\" syntax=\"1.3.6.1.4.1.1466.115.121.1.26\">\n" +
         "        <ts:origins>\n" +
-        "            <ts:ethereum as=\"utf8\" function=\"symbol\">\n" +
-        "            </ts:ethereum>\n" +
+        "            <ethereum:call as=\"utf8\" function=\"symbol\">\n" +
+        "            </ethereum:call>\n" +
         "        </ts:origins>\n" +
         "    </ts:attribute-type>\n" +
         "</ts:token>\n",

--- a/index.js
+++ b/index.js
@@ -143,7 +143,7 @@ document.addEventListener("DOMContentLoaded", () => {
         xmlFile.getElementsByTagName("ts:contract")[0].children[0].value = contractAddress;
         xmlFile.getElementsByTagName("ts:cards")[0].getElementsByTagName("ts:action")[1]
             .getElementsByTagName("ts:transaction")[0].
-        getElementsByTagName("ts:ethereum")[0].setAttribute("contract", contractName);
+        getElementsByTagName("ethereum:call")[0].setAttribute("contract", contractName);
 
         //set stripped entity tags
         xmlFile.getElementsByTagName("ts:token")[0].getElementsByTagName("ts:cards")[0].getElementsByTagName("ts:action")[0]
@@ -197,7 +197,7 @@ document.addEventListener("DOMContentLoaded", () => {
         nameNode.appendChild(stringNodeName);
         attributeTypeNode.appendChild(nameNode);
         let originNode = document.createElement("ts:origins");
-        let ethereumNode = document.createElement("ts:ethereum");
+        let ethereumNode = document.createElement("ethereum:call");
         ethereumNode.setAttribute("function", func.name);
         ethereumNode.setAttribute("contract", contractName);
         let AS = getAS(func.outputs);

--- a/index.js
+++ b/index.js
@@ -136,26 +136,26 @@ document.addEventListener("DOMContentLoaded", () => {
         //set network
         xmlFile.getElementsByTagName("ts:contract")[0].getElementsByTagName("ts:address")[0].setAttribute("network", network);
 
-        xmlFile.getElementsByTagName("ts:name")[0].getElementsByTagName("ts:string")[0].innerHTML = contractName;
+        xmlFile.getElementsByTagName("ts:label")[0].getElementsByTagName("ts:string")[0].innerHTML = contractName;
         xmlFile.getElementsByTagName("ts:contract")[0].getElementsByTagName("ts:address")[0].innerHTML = contractAddress;
         xmlFile.getElementsByTagName("ts:origins")[0].getElementsByTagName("ts:ethereum")[0].setAttribute("contract", contractName);
         xmlFile.getElementsByTagName("ts:contract")[0].attributes.name.value = contractName;
         xmlFile.getElementsByTagName("ts:contract")[0].children[0].value = contractAddress;
-        xmlFile.getElementsByTagName("ts:cards")[0].getElementsByTagName("ts:action")[1]
+        xmlFile.getElementsByTagName("ts:cards")[0].getElementsByTagName("ts:card")[1]
             .getElementsByTagName("ts:transaction")[0].
         getElementsByTagName("ethereum:call")[0].setAttribute("contract", contractName);
 
         //set stripped entity tags
-        xmlFile.getElementsByTagName("ts:token")[0].getElementsByTagName("ts:cards")[0].getElementsByTagName("ts:action")[0]
+        xmlFile.getElementsByTagName("ts:token")[0].getElementsByTagName("ts:cards")[0].getElementsByTagName("ts:card")[0]
             .getElementsByTagName("ts:view")[0].getElementsByTagName("xhtml:style")[0].innerHTML = "&style;";
         xmlFile.getElementsByTagName("ts:token")[0].getElementsByTagName("ts:cards")[0]
-            .getElementsByTagName("ts:action")[0].getElementsByTagName("ts:view")[0]
+            .getElementsByTagName("ts:card")[0].getElementsByTagName("ts:view")[0]
             .getElementsByTagName("xhtml:script")[0].innerHTML = "&about.en;";
 
-        xmlFile.getElementsByTagName("ts:token")[0].getElementsByTagName("ts:cards")[0].getElementsByTagName("ts:action")[1]
+        xmlFile.getElementsByTagName("ts:token")[0].getElementsByTagName("ts:cards")[0].getElementsByTagName("ts:card")[1]
             .getElementsByTagName("ts:view")[0].getElementsByTagName("xhtml:style")[0].innerHTML = "&style;";
         xmlFile.getElementsByTagName("ts:token")[0].getElementsByTagName("ts:cards")[0]
-            .getElementsByTagName("ts:action")[1].getElementsByTagName("ts:view")[0]
+            .getElementsByTagName("ts:card")[1].getElementsByTagName("ts:view")[0]
             .getElementsByTagName("xhtml:script")[0].innerHTML = "&approve.en;";
 
         return xmlFile;
@@ -165,7 +165,7 @@ document.addEventListener("DOMContentLoaded", () => {
         let eventParams = [];
         for(let eventInput of eventAbi.inputs) {
             let elementNode = document.createElement("element");
-            elementNode.setAttribute("name", eventInput.name);
+            elementNode.setAttribute("label", eventInput.name);
             elementNode.setAttribute("ethereum:type", eventInput.type);
             elementNode.setAttribute("ethereum:indexed", eventInput.indexed);
             eventParams.push(elementNode);
@@ -185,12 +185,12 @@ document.addEventListener("DOMContentLoaded", () => {
     function getAttribute(func, contractName) {
         let data = getData(func);
         let attributeTypeNode = document.createElement("ts:attribute-type");
-        attributeTypeNode.setAttribute("id", func.name);
+        attributeTypeNode.setAttribute("name", func.name);
         let syntax = getSyntax(func.outputs);
         if(syntax !== "") {
             attributeTypeNode.setAttribute("syntax", syntax);
         }
-        let nameNode = document.createElement("ts:name");
+        let nameNode = document.createElement("ts:label");
         let stringNodeName = document.createElement("ts:string");
         stringNodeName.setAttribute("xml:lang", "en");
         stringNodeName.innerText = func.name;

--- a/samples/erc20/erc20.xml
+++ b/samples/erc20/erc20.xml
@@ -50,12 +50,12 @@
                 </ts:origins>
             </ts:attribute-type>
             <ts:transaction>
-                <ts:ethereum function="approve" contract="" as="uint">
+                <ethereum:call function="approve" contract="" as="uint">
                     <ts:data>
                         <ts:address ref="approvalAddress"/>
                         <ts:uint256>115792089237316195423570985008687907853269984665640564039457584007913129639935</ts:uint256>
                     </ts:data>
-                </ts:ethereum>
+                </ethereum:call>
             </ts:transaction>
             <ts:view xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
                 <xhtml:style type="text/css">&style;</xhtml:style>
@@ -63,11 +63,12 @@
             </ts:view>
         </ts:action>
     </ts:cards>
-    <!-- placeholder for future functions -->
+
     <ts:attribute-type id="symbol" syntax="1.3.6.1.4.1.1466.115.121.1.26">
         <ts:origins>
-            <ts:ethereum as="utf8" function="symbol">
-            </ts:ethereum>
+            <ethereum:call as="utf8" function="symbol">
+            </ethereum:call>
         </ts:origins>
     </ts:attribute-type>
+
 </ts:token>

--- a/samples/erc20/erc20.xml
+++ b/samples/erc20/erc20.xml
@@ -13,9 +13,9 @@
           xmlns:ethereum="urn:ethereum:constantinople"
           custodian="false"
 >
-    <ts:name>
+    <ts:label>
         <ts:string xml:lang="en"></ts:string>
-    </ts:name>
+    </ts:label>
     <ts:contract interface="erc20" name="">
         <ts:address network="1"></ts:address>     <!--mainnet-->
     </ts:contract>
@@ -27,24 +27,24 @@
     </ts:origins>
 
     <ts:cards>
-        <ts:action>
-            <ts:name>
+        <ts:card type="action">
+            <ts:label>
                 <ts:string xml:lang="en">About</ts:string>
-            </ts:name>
+            </ts:label>
             <ts:view xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
                 <xhtml:style type="text/css">&style;</xhtml:style>
                 <xhtml:script type="text/javascript">&about.en;</xhtml:script>
             </ts:view>
-        </ts:action>
+        </ts:card>
 
-        <ts:action>
-            <ts:name>
+        <ts:card type="action">
+            <ts:label>
                 <ts:string xml:lang="en">Approve</ts:string>
-            </ts:name>
+            </ts:label>
             <ts:attribute-type id="approvalAddress" syntax="1.3.6.1.4.1.1466.115.121.1.36">
-                <ts:name>
+                <ts:label>
                     <ts:string xml:lang="en">Approval Address</ts:string>
-                </ts:name>
+                </ts:label>
                 <ts:origins>
                     <ts:user-entry as="address"/>
                 </ts:origins>
@@ -61,10 +61,10 @@
                 <xhtml:style type="text/css">&style;</xhtml:style>
                 <xhtml:script type="text/javascript">&approve.en;</xhtml:script>
             </ts:view>
-        </ts:action>
+        </ts:card>
     </ts:cards>
 
-    <ts:attribute-type id="symbol" syntax="1.3.6.1.4.1.1466.115.121.1.26">
+    <ts:attribute-type name="symbol" syntax="1.3.6.1.4.1.1466.115.121.1.26">
         <ts:origins>
             <ethereum:call as="utf8" function="symbol">
             </ethereum:call>

--- a/samples/erc20/erc20.xml
+++ b/samples/erc20/erc20.xml
@@ -4,10 +4,10 @@
         <!ENTITY about.en SYSTEM "about.en.js">
         <!ENTITY approve.en SYSTEM "approve.en.js">
         ]>
-<ts:token xmlns:ts="http://tokenscript.org/2020/03/tokenscript"
+<ts:token xmlns:ts="http://tokenscript.org/2020/06/tokenscript"
           xmlns:xhtml="http://www.w3.org/1999/xhtml"
           xmlns:xml="http://www.w3.org/XML/1998/namespace"
-          xsi:schemaLocation="http://tokenscript.org/2020/03/tokenscript http://tokenscript.org/2020/03/tokenscript.xsd"
+          xsi:schemaLocation="http://tokenscript.org/2020/06/tokenscript http://tokenscript.org/2020/06/tokenscript.xsd"
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xmlns:asnx="urn:ietf:params:xml:ns:asnx"
           xmlns:ethereum="urn:ethereum:constantinople"

--- a/samples/erc721/erc721.xml
+++ b/samples/erc721/erc721.xml
@@ -50,12 +50,12 @@
                 </ts:origins>
             </ts:attribute-type>
             <ts:transaction>
-                <ts:ethereum function="approve" contract="" as="uint">
+                <ethereum:call function="approve" contract="" as="uint">
                     <ts:data>
                         <ts:address ref="approvalAddress"/>
                         <ts:uint256 ref="tokenId"/>
                     </ts:data>
-                </ts:ethereum>
+                </ethereum:call>
             </ts:transaction>
             <ts:view xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
                 <xhtml:style type="text/css">&style;</xhtml:style>
@@ -63,11 +63,11 @@
             </ts:view>
         </ts:action>
     </ts:cards>
-    <!-- placeholder for future functions -->
+
     <ts:attribute-type id="symbol" syntax="1.3.6.1.4.1.1466.115.121.1.26">
         <ts:origins>
-            <ts:ethereum as="utf8" function="symbol">
-            </ts:ethereum>
+            <ethereum:call as="utf8" function="symbol">
+            </ethereum:call>
         </ts:origins>
     </ts:attribute-type>
 </ts:token>

--- a/samples/erc721/erc721.xml
+++ b/samples/erc721/erc721.xml
@@ -13,9 +13,9 @@
           xmlns:ethereum="urn:ethereum:constantinople"
           custodian="false"
 >
-    <ts:name>
+    <ts:label>
         <ts:string xml:lang="en"></ts:string>
-    </ts:name>
+    </ts:label>
     <ts:contract interface="erc721" name="">
         <ts:address network="1"></ts:address>     <!--mainnet-->
     </ts:contract>
@@ -27,24 +27,24 @@
     </ts:origins>
 
     <ts:cards>
-        <ts:action>
-            <ts:name>
+        <ts:card type="action">
+            <ts:label>
                 <ts:string xml:lang="en">About</ts:string>
-            </ts:name>
+            </ts:label>
             <ts:view xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
                 <xhtml:style type="text/css">&style;</xhtml:style>
                 <xhtml:script type="text/javascript">&about.en;</xhtml:script>
             </ts:view>
-        </ts:action>
+        </ts:card>
 
-        <ts:action>
-            <ts:name>
+        <ts:card type="action">
+            <ts:label>
                 <ts:string xml:lang="en">Approve</ts:string>
-            </ts:name>
+            </ts:label>
             <ts:attribute-type id="approvalAddress" syntax="1.3.6.1.4.1.1466.115.121.1.36">
-                <ts:name>
+                <ts:label>
                     <ts:string xml:lang="en">Approval Address</ts:string>
-                </ts:name>
+                </ts:label>
                 <ts:origins>
                     <ts:user-entry as="address"/>
                 </ts:origins>
@@ -61,10 +61,10 @@
                 <xhtml:style type="text/css">&style;</xhtml:style>
                 <xhtml:script type="text/javascript">&approve.en;</xhtml:script>
             </ts:view>
-        </ts:action>
+        </ts:card>
     </ts:cards>
 
-    <ts:attribute-type id="symbol" syntax="1.3.6.1.4.1.1466.115.121.1.26">
+    <ts:attribute-type name="symbol" syntax="1.3.6.1.4.1.1466.115.121.1.26">
         <ts:origins>
             <ethereum:call as="utf8" function="symbol">
             </ethereum:call>

--- a/samples/erc721/erc721.xml
+++ b/samples/erc721/erc721.xml
@@ -4,10 +4,10 @@
         <!ENTITY about.en SYSTEM "about.en.js">
         <!ENTITY approve.en SYSTEM "approve.en.js">
         ]>
-<ts:token xmlns:ts="http://tokenscript.org/2020/03/tokenscript"
+<ts:token xmlns:ts="http://tokenscript.org/2020/06/tokenscript"
           xmlns:xhtml="http://www.w3.org/1999/xhtml"
           xmlns:xml="http://www.w3.org/XML/1998/namespace"
-          xsi:schemaLocation="http://tokenscript.org/2020/03/tokenscript http://tokenscript.org/2020/03/tokenscript.xsd"
+          xsi:schemaLocation="http://tokenscript.org/2020/06/tokenscript http://tokenscript.org/2020/06/tokenscript.xsd"
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xmlns:asnx="urn:ietf:params:xml:ns:asnx"
           xmlns:ethereum="urn:ethereum:constantinople"

--- a/templates.js
+++ b/templates.js
@@ -14,10 +14,10 @@ module.exports = {
         "        <!ENTITY about.en SYSTEM \"about.en.js\">\n" +
         "        <!ENTITY approve.en SYSTEM \"approve.en.js\">\n" +
         "        ]>\n" +
-        "<ts:token xmlns:ts=\"http://tokenscript.org/2020/03/tokenscript\"\n" +
+        "<ts:token xmlns:ts=\"http://tokenscript.org/2020/06/tokenscript\"\n" +
         "          xmlns:xhtml=\"http://www.w3.org/1999/xhtml\"\n" +
         "          xmlns:xml=\"http://www.w3.org/XML/1998/namespace\"\n" +
-        "          xsi:schemaLocation=\"http://tokenscript.org/2020/03/tokenscript http://tokenscript.org/2020/03/tokenscript.xsd\"\n" +
+        "          xsi:schemaLocation=\"http://tokenscript.org/2020/06/tokenscript http://tokenscript.org/2020/06/tokenscript.xsd\"\n" +
         "          xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n" +
         "          xmlns:asnx=\"urn:ietf:params:xml:ns:asnx\"\n" +
         "          xmlns:ethereum=\"urn:ethereum:constantinople\"\n" +
@@ -89,10 +89,10 @@ module.exports = {
         "        <!ENTITY about.en SYSTEM \"about.en.js\">\n" +
         "        <!ENTITY approve.en SYSTEM \"approve.en.js\">\n" +
         "        ]>\n" +
-        "<ts:token xmlns:ts=\"http://tokenscript.org/2020/03/tokenscript\"\n" +
+        "<ts:token xmlns:ts=\"http://tokenscript.org/2020/06/tokenscript\"\n" +
         "          xmlns:xhtml=\"http://www.w3.org/1999/xhtml\"\n" +
         "          xmlns:xml=\"http://www.w3.org/XML/1998/namespace\"\n" +
-        "          xsi:schemaLocation=\"http://tokenscript.org/2020/03/tokenscript http://tokenscript.org/2020/03/tokenscript.xsd\"\n" +
+        "          xsi:schemaLocation=\"http://tokenscript.org/2020/06/tokenscript http://tokenscript.org/2020/06/tokenscript.xsd\"\n" +
         "          xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n" +
         "          xmlns:asnx=\"urn:ietf:params:xml:ns:asnx\"\n" +
         "          xmlns:ethereum=\"urn:ethereum:constantinople\"\n" +

--- a/templates.js
+++ b/templates.js
@@ -23,9 +23,9 @@ module.exports = {
         "          xmlns:ethereum=\"urn:ethereum:constantinople\"\n" +
         "          custodian=\"false\"\n" +
         ">\n" +
-        "    <ts:name>\n" +
+        "    <ts:label>\n" +
         "        <ts:string xml:lang=\"en\"></ts:string>\n" +
-        "    </ts:name>\n" +
+        "    </ts:label>\n" +
         "    <ts:contract interface=\"erc20\" name=\"\">\n" +
         "        <ts:address network=\"1\"></ts:address>     <!--mainnet-->\n" +
         "    </ts:contract>\n" +
@@ -37,24 +37,24 @@ module.exports = {
         "    </ts:origins>\n" +
         "\n" +
         "    <ts:cards>\n" +
-        "        <ts:action>\n" +
-        "            <ts:name>\n" +
+        "        <ts:card type=\"action\">\n" +
+        "            <ts:label>\n" +
         "                <ts:string xml:lang=\"en\">About</ts:string>\n" +
-        "            </ts:name>\n" +
+        "            </ts:label>\n" +
         "            <ts:view xmlns=\"http://www.w3.org/1999/xhtml\" xml:lang=\"en\">\n" +
         "                <xhtml:style type=\"text/css\">&style;</xhtml:style>\n" +
         "                <xhtml:script type=\"text/javascript\">&about.en;</xhtml:script>\n" +
         "            </ts:view>\n" +
-        "        </ts:action>\n" +
+        "        </ts:card>\n" +
         "\n" +
-        "        <ts:action>\n" +
-        "            <ts:name>\n" +
+        "        <ts:card type=\"action\">\n" +
+        "            <ts:label>\n" +
         "                <ts:string xml:lang=\"en\">Approve</ts:string>\n" +
-        "            </ts:name>\n" +
+        "            </ts:label>\n" +
         "            <ts:attribute-type id=\"approvalAddress\" syntax=\"1.3.6.1.4.1.1466.115.121.1.36\">\n" +
-        "                <ts:name>\n" +
+        "                <ts:label>\n" +
         "                    <ts:string xml:lang=\"en\">Approval Address</ts:string>\n" +
-        "                </ts:name>\n" +
+        "                </ts:label>\n" +
         "                <ts:origins>\n" +
         "                    <ts:user-entry as=\"address\"/>\n" +
         "                </ts:origins>\n" +
@@ -71,10 +71,10 @@ module.exports = {
         "                <xhtml:style type=\"text/css\">&style;</xhtml:style>\n" +
         "                <xhtml:script type=\"text/javascript\">&approve.en;</xhtml:script>\n" +
         "            </ts:view>\n" +
-        "        </ts:action>\n" +
+        "        </ts:card>\n" +
         "    </ts:cards>\n" +
         "\n" +
-        "    <ts:attribute-type id=\"symbol\" syntax=\"1.3.6.1.4.1.1466.115.121.1.26\">\n" +
+        "    <ts:attribute-type name=\"symbol\" syntax=\"1.3.6.1.4.1.1466.115.121.1.26\">\n" +
         "        <ts:origins>\n" +
         "            <ethereum:call as=\"utf8\" function=\"symbol\">\n" +
         "            </ethereum:call>\n" +
@@ -98,9 +98,9 @@ module.exports = {
         "          xmlns:ethereum=\"urn:ethereum:constantinople\"\n" +
         "          custodian=\"false\"\n" +
         ">\n" +
-        "    <ts:name>\n" +
+        "    <ts:label>\n" +
         "        <ts:string xml:lang=\"en\"></ts:string>\n" +
-        "    </ts:name>\n" +
+        "    </ts:label>\n" +
         "    <ts:contract interface=\"erc721\" name=\"\">\n" +
         "        <ts:address network=\"1\"></ts:address>     <!--mainnet-->\n" +
         "    </ts:contract>\n" +
@@ -112,24 +112,24 @@ module.exports = {
         "    </ts:origins>\n" +
         "\n" +
         "    <ts:cards>\n" +
-        "        <ts:action>\n" +
-        "            <ts:name>\n" +
+        "        <ts:card type=\"action\">\n" +
+        "            <ts:label>\n" +
         "                <ts:string xml:lang=\"en\">About</ts:string>\n" +
-        "            </ts:name>\n" +
+        "            </ts:label>\n" +
         "            <ts:view xmlns=\"http://www.w3.org/1999/xhtml\" xml:lang=\"en\">\n" +
         "                <xhtml:style type=\"text/css\">&style;</xhtml:style>\n" +
         "                <xhtml:script type=\"text/javascript\">&about.en;</xhtml:script>\n" +
         "            </ts:view>\n" +
-        "        </ts:action>\n" +
+        "        </ts:card>\n" +
         "\n" +
-        "        <ts:action>\n" +
-        "            <ts:name>\n" +
+        "        <ts:card type=\"action\">\n" +
+        "            <ts:label>\n" +
         "                <ts:string xml:lang=\"en\">Approve</ts:string>\n" +
-        "            </ts:name>\n" +
+        "            </ts:label>\n" +
         "            <ts:attribute-type id=\"approvalAddress\" syntax=\"1.3.6.1.4.1.1466.115.121.1.36\">\n" +
-        "                <ts:name>\n" +
+        "                <ts:label>\n" +
         "                    <ts:string xml:lang=\"en\">Approval Address</ts:string>\n" +
-        "                </ts:name>\n" +
+        "                </ts:label>\n" +
         "                <ts:origins>\n" +
         "                    <ts:user-entry as=\"address\"/>\n" +
         "                </ts:origins>\n" +
@@ -146,10 +146,10 @@ module.exports = {
         "                <xhtml:style type=\"text/css\">&style;</xhtml:style>\n" +
         "                <xhtml:script type=\"text/javascript\">&approve.en;</xhtml:script>\n" +
         "            </ts:view>\n" +
-        "        </ts:action>\n" +
+        "        </ts:card>\n" +
         "    </ts:cards>\n" +
         "\n" +
-        "    <ts:attribute-type id=\"symbol\" syntax=\"1.3.6.1.4.1.1466.115.121.1.26\">\n" +
+        "    <ts:attribute-type name=\"symbol\" syntax=\"1.3.6.1.4.1.1466.115.121.1.26\">\n" +
         "        <ts:origins>\n" +
         "            <ethereum:call as=\"utf8\" function=\"symbol\">\n" +
         "            </ethereum:call>\n" +

--- a/templates.js
+++ b/templates.js
@@ -60,12 +60,12 @@ module.exports = {
         "                </ts:origins>\n" +
         "            </ts:attribute-type>\n" +
         "            <ts:transaction>\n" +
-        "                <ts:ethereum function=\"approve\" contract=\"\" as=\"uint\">\n" +
+        "                <ethereum:call function=\"approve\" contract=\"\" as=\"uint\">\n" +
         "                    <ts:data>\n" +
         "                        <ts:address ref=\"approvalAddress\"/>\n" +
         "                        <ts:uint256>115792089237316195423570985008687907853269984665640564039457584007913129639935</ts:uint256>\n" +
         "                    </ts:data>\n" +
-        "                </ts:ethereum>\n" +
+        "                </ethereum:call>\n" +
         "            </ts:transaction>\n" +
         "            <ts:view xmlns=\"http://www.w3.org/1999/xhtml\" xml:lang=\"en\">\n" +
         "                <xhtml:style type=\"text/css\">&style;</xhtml:style>\n" +
@@ -73,13 +73,14 @@ module.exports = {
         "            </ts:view>\n" +
         "        </ts:action>\n" +
         "    </ts:cards>\n" +
-        "    <!-- placeholder for future functions -->\n" +
+        "\n" +
         "    <ts:attribute-type id=\"symbol\" syntax=\"1.3.6.1.4.1.1466.115.121.1.26\">\n" +
         "        <ts:origins>\n" +
-        "            <ts:ethereum as=\"utf8\" function=\"symbol\">\n" +
-        "            </ts:ethereum>\n" +
+        "            <ethereum:call as=\"utf8\" function=\"symbol\">\n" +
+        "            </ethereum:call>\n" +
         "        </ts:origins>\n" +
         "    </ts:attribute-type>\n" +
+        "\n" +
         "</ts:token>\n",
 
     erc721XML: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
@@ -134,12 +135,12 @@ module.exports = {
         "                </ts:origins>\n" +
         "            </ts:attribute-type>\n" +
         "            <ts:transaction>\n" +
-        "                <ts:ethereum function=\"approve\" contract=\"\" as=\"uint\">\n" +
+        "                <ethereum:call function=\"approve\" contract=\"\" as=\"uint\">\n" +
         "                    <ts:data>\n" +
         "                        <ts:address ref=\"approvalAddress\"/>\n" +
         "                        <ts:uint256 ref=\"tokenId\"/>\n" +
         "                    </ts:data>\n" +
-        "                </ts:ethereum>\n" +
+        "                </ethereum:call>\n" +
         "            </ts:transaction>\n" +
         "            <ts:view xmlns=\"http://www.w3.org/1999/xhtml\" xml:lang=\"en\">\n" +
         "                <xhtml:style type=\"text/css\">&style;</xhtml:style>\n" +
@@ -147,11 +148,11 @@ module.exports = {
         "            </ts:view>\n" +
         "        </ts:action>\n" +
         "    </ts:cards>\n" +
-        "    <!-- placeholder for future functions -->\n" +
+        "\n" +
         "    <ts:attribute-type id=\"symbol\" syntax=\"1.3.6.1.4.1.1466.115.121.1.26\">\n" +
         "        <ts:origins>\n" +
-        "            <ts:ethereum as=\"utf8\" function=\"symbol\">\n" +
-        "            </ts:ethereum>\n" +
+        "            <ethereum:call as=\"utf8\" function=\"symbol\">\n" +
+        "            </ethereum:call>\n" +
         "        </ts:origins>\n" +
         "    </ts:attribute-type>\n" +
         "</ts:token>\n",


### PR DESCRIPTION
Closes #10 

> In cards, Ethereum stuff moved to Ethereum namespace
In attribute <origins>, <ts:ethereum> is replaced by either <ethereum:call> or <ethereum:event>.
In action card <transaction>, <ts:ethereum> is replaced by either <ethereum:call> or <ethereum:transfer>.

@colourful-land we never used ts:ethereum for events, please clarify your position. 